### PR TITLE
Remove $LD_LIBRARY_PATH variable from LD_LIBRARY_PATH definition.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ apps:
     plugs: [network, audio-playback, x11, network-bind]
     environment:
        LC_ALL: C.UTF-8
-       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/samba:$LD_LIBRARY_PATH"
+       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/samba"
 
 parts:
   pyradio:


### PR DESCRIPTION
$LD_LIBRARY_PATH starts as null and thus leaves a trailing colon.
An extra colon will be added in a later invocation of snapcraft_runner,
and will result in the current working directory being searched by ld.

(See my comments at https://forum.snapcraft.io/t/ann-snapcraft-4-4-4-library-injection-vulnerability-on-built-snaps/21465/5?u=james-carroll )