### PR TITLE
fix: migrate pyradio to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
 
   This snap is maintained by the Snapcrafters community, and is not necessarily endorsed or officially maintained by the upstream developers.
 
-base: core20
+base: core24
 grade: stable
 confinement: strict
 
@@ -18,10 +18,10 @@ source-code: https://github.com//snapcrafters/pyradio
 license: MIT
 version: '0.9.3.11.31'
 
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
+platforms:
+  amd64:
+  arm64:
+  armhf:
 
 apps:
   pyradio:
@@ -45,5 +45,5 @@ parts:
         - samba-libs
         - libgpm2
         - libglu1-mesa
-        - freeglut3
+        - libglut3.12
         - libslang2


### PR DESCRIPTION
## Summary

- migrate the snap from `core20` to `core24`
- replace the legacy `architectures` key with `platforms`
- update the Noble stage package rename from `freeglut3` to `libglut3.12`

## Why

The original release failure was caused by the old core20 Python build environment rejecting upstream PyRadio's current `pyproject.toml` license metadata.

Moving to core24 is a cleaner fix than carrying a pyproject patch: Ubuntu 24.04 / the current Python packaging stack builds upstream `pyradio` 0.9.3.11.31 without modifying `license = "MIT"`.

After the core24 migration, PR CI then exposed the expected Noble package rename:

```text
Stage package not found in part 'pyradio': freeglut3.
```

In Noble, the runtime package is `libglut3.12` from the `freeglut` source package.

## Verification

- Parsed `snap/snapcraft.yaml` with Python/YAML.
- Confirmed `base: core24`.
- Confirmed `platforms` contains `amd64`, `arm64`, and `armhf`.
- Confirmed `architectures` is no longer present.
- Confirmed the stage packages are:
  - `mplayer`
  - `libpulse0`
  - `samba-libs`
  - `libgpm2`
  - `libglu1-mesa`
  - `libglut3.12`
  - `libslang2`
- Checked all of those packages are available in Ubuntu Noble for `amd64`, `arm64`, and `armhf` via packages.ubuntu.com.
- Simulated installing the final stage package set in an `ubuntu:24.04` container.
- Verified upstream `coderholic/pyradio` tag `0.9.3.11.31` builds and installs with Python packaging tools in an `ubuntu:24.04` container without any `pyproject.toml` license patch.
- Ran `git diff --check`.

@jnsgruk please review.
