### PR TITLE
fix: clear libmpeg2 executable stack in core24 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,15 @@ parts:
         - dnspython
         - psutil
         - requests
+    build-packages:
+        - execstack
+    override-prime: |
+      craftctl default
+
+      libmpeg2="$CRAFT_PRIME/usr/lib/arm-linux-gnueabihf/libmpeg2.so.0.1.0"
+      if [ -e "$libmpeg2" ]; then
+        execstack --clear-execstack "$libmpeg2"
+      fi
     stage-packages:
         - mplayer
         - libpulse0


### PR DESCRIPTION
## Summary

- keep the `core24` migration from `candidate`
- install `execstack` as a build package
- clear the executable-stack bit from the staged armhf `libmpeg2.so.0.1.0` during `override-prime`

## Why

The release job failed snap review for the core24 armhf build:

```text
Warnings
--------
 - functional-snap-v2:execstack
	Found files with executable stack. This adds PROT_EXEC to mmap(2) during mediation which may cause security denials. Either adjust your program to not require an executable stack, strip it with 'execstack --clear-execstack ...' or remove the affected file from your snap. Affected files: usr/lib/arm-linux-gnueabihf/libmpeg2.so.0.1.0
	https://forum.snapcraft.io/t/snap-and-executable-stacks/1812
pyradio_0.9.3.11.31_armhf.snap: FAIL
```

The affected file is staged from Noble's `libmpeg2-4:armhf`. It does not need an executable stack for the snap, so the packaging clears the flag after normal priming and before review/upload.

## Verification

- Parsed `snap/snapcraft.yaml` with Python/YAML.
- Confirmed `base: core24` and `platforms` still include `amd64`, `arm64`, and `armhf`.
- Confirmed `architectures` is absent.
- Confirmed `build-packages` includes `execstack`.
- Confirmed `override-prime` runs `craftctl default`, then clears `$CRAFT_PRIME/usr/lib/arm-linux-gnueabihf/libmpeg2.so.0.1.0` only when that file exists.
- Checked Noble apt metadata for all stage packages on `amd64`, `arm64`, and `armhf`.
- Checked Noble apt metadata for `execstack`.
- Downloaded `libmpeg2-4:armhf` in an `ubuntu:24.04` container and verified the exact file path exists.
- In an `ubuntu:24.04` container with `execstack` installed, verified:
  - before: `X .../usr/lib/arm-linux-gnueabihf/libmpeg2.so.0.1.0`
  - after `execstack --clear-execstack`: `- .../usr/lib/arm-linux-gnueabihf/libmpeg2.so.0.1.0`
- Ran `git diff --check`.

@jnsgruk please review.
