### PR TITLE
fix: bundle mpv player

### DIFF
--- a/snap/local/mpv
+++ b/snap/local/mpv
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+# Set staged library paths here, not only in pyradio-wrapper, so direct
+# tests such as `$SNAP/bin/mpv <url>` work from `snap run --shell pyradio` and
+# PyRadio's spawned mpv process has the same environment.
+for libdir in "$SNAP"/usr/lib/* "$SNAP"/usr/lib/*/pulseaudio "$SNAP"/usr/lib/*/blas "$SNAP"/usr/lib/*/lapack; do
+    if [ -d "$libdir" ]; then
+        export LD_LIBRARY_PATH="$libdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    fi
+done
+
+if [ -z "${PULSE_SERVER:-}" ] && [ -S "/run/user/$(id -u)/pulse/native" ]; then
+    export PULSE_SERVER="unix:/run/user/$(id -u)/pulse/native"
+fi
+
+# Keep mpv's config lookup inside the snap's user data. PyRadio writes a
+# [pyradio] mpv profile there and launches mpv with --profile=pyradio, so
+# --no-config breaks full-app playback even though direct mpv tests work.
+mkdir -p "$SNAP_USER_DATA/.config/mpv"
+
+# Force PulseAudio. In this snap mpv's default AO probing falls through
+# PipeWire/ALSA/JACK/SDL paths whose host configuration is not available under
+# strict confinement. The audio-playback interface supports the PulseAudio API
+# (including pipewire-pulse on modern desktops), so use that directly.
+exec "$SNAP/usr/bin/mpv" --config-dir="$SNAP_USER_DATA/.config/mpv" --ao=pulse "$@"

--- a/snap/local/pyradio-mpv-socket.patch
+++ b/snap/local/pyradio-mpv-socket.patch
@@ -1,0 +1,11 @@
+--- a/pyradio/player.py
++++ b/pyradio/player.py
+@@ -2625,7 +2625,7 @@
+         if platform.startswith('win'):
+             mpvsocket = r'\\.\pipe\mpvsocket.{}'.format(os.getpid())
+         else:
+-            mpvsocket = '/tmp/mpvsocket.{}'.format(os.getpid())
++            mpvsocket = os.path.join(os.environ.get('SNAP_USER_COMMON', '/tmp'), 'mpvsocket.{}'.format(os.getpid()))
+         if logger.isEnabledFor(logging.DEBUG):
+             logger.debug(f'mpv socket is "{mpvsocket}"')
+         if os.path.exists(mpvsocket):

--- a/snap/local/pyradio-wrapper
+++ b/snap/local/pyradio-wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+# PyRadio probes players by executable name. Strict snaps cannot rely on
+# host-installed players, so prefer snap-local command shims first, then the
+# staged package binaries.
+export PATH="$SNAP/bin:$SNAP/usr/bin:$PATH"
+
+exec "$SNAP/bin/pyradio" --use-player mpv "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,10 +25,11 @@ platforms:
 
 apps:
   pyradio:
-    command: bin/pyradio
+    command: bin/pyradio-wrapper
     plugs:
         - audio-playback
         - network
+        - network-bind
 
 parts:
   pyradio:
@@ -36,3 +37,19 @@ parts:
     source: https://github.com/coderholic/pyradio.git
     python-requirements:
         - requirements_pipx.txt
+    override-build: |
+        git apply "$CRAFT_PROJECT_DIR/snap/local/pyradio-mpv-socket.patch"
+        grep -F "SNAP_USER_COMMON" pyradio/player.py
+        craftctl default
+    stage-packages:
+        - mpv
+        - libblas3
+
+  pyradio-wrapper:
+    plugin: dump
+    source: snap/local
+    organize:
+        mpv: bin/mpv
+        pyradio-wrapper: bin/pyradio-wrapper
+    after:
+        - pyradio


### PR DESCRIPTION
## Summary

- Bundle `mpv` in the snap so PyRadio does not depend on host-installed players.
- Launch PyRadio through `snap/local/pyradio-wrapper`, putting snap-local commands first in `PATH` and forcing `--use-player mpv`.
- Add `snap/local/mpv` as a small mpv wrapper that sets staged library paths, points PulseAudio at the user session socket when available, keeps PyRadio's generated mpv profile usable, and forces `--ao=pulse`.
- Apply `snap/local/pyradio-mpv-socket.patch` during `override-build` so PyRadio puts its mpv IPC socket under `SNAP_USER_COMMON` instead of `/tmp`.
- Keep the patch minimal: no explicit fontconfig staging/exports, and no AppArmor-denial cleanup beyond what is needed for playback.

## Test plan

- [x] `git diff --check`
- [x] Verified `snap/local/pyradio-mpv-socket.patch` applies cleanly to upstream `coderholic/pyradio`.
- [x] Local `snapcraft pack` succeeded and produced `pyradio_0.9.3.11.31_amd64.snap`.
- [x] Installed the locally built snap in the LXD desktop VM `pyradio-desktop-test`.
- [x] Direct snap-local mpv smoke test played a SomaFM stream through PulseAudio and exited 0, showing `AO: [pulse] 44100Hz stereo 2ch float`.
- [x] Full PyRadio smoke test in the desktop VM selected `mpv`, opened station 1, reached `Playing`, showed a track title, and did not hit the previous `Could not listen on IPC socket` failure.
- [x] PR CI is green for the latest head: https://github.com/snapcrafters/pyradio/actions/runs/27064674816

@jnsgruk please review.
